### PR TITLE
Fix in identation of Chapter 12

### DIFF
--- a/_chapters/12-faqs.md
+++ b/_chapters/12-faqs.md
@@ -46,8 +46,8 @@ E o CSS:
 	/* módulo */
 	.carrinho {}
 
-/* componente de título para o módulo de carrinho */
-.carrinho .titulo {}
+	/* componente de título para o módulo de carrinho */
+	.carrinho .titulo {}
 
 Há dois problemas:
 


### PR DESCRIPTION
Corrigida a indentação do bloco CSS referente ao tópico "Porque eu devo prefixar o nome do módulo?"