### PR TITLE
:pencil2: Corrige palavra Carrino para Carrinho

### DIFF
--- a/_chapters/11-organisation.md
+++ b/_chapters/11-organisation.md
@@ -44,7 +44,7 @@ Esta abordagem coloca os CSS específicos de módulos em seus próprios diretór
 			carrinho.html
 			carrinhoVazio.html
 		/partials
-			cabecalhoCarrino.html
+			cabecalhoCarrinho.html
 			resumoCarrinho.html
 		/js
 			...


### PR DESCRIPTION
Correção de um erro sutil ao escrever a palavra carrinho corrigido.